### PR TITLE
Update page's organisation mentions to the new name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ public
 .intermediate-representation/
 .cache/
 yarn.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ public
 .intermediate-representation/
 .cache/
 yarn.lock
-.idea

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,8 +1,8 @@
 module.exports = {
   siteMetadata: {
-    title: "Gastown Gang - landing page",
+    title: "Cambie Collective - landing page",
     author: "Manil Chowdhury",
-    description: "the front-facing page for Gastown Gang"
+    description: "the front-facing page for Cambie Collective"
   },
   pathPrefix: '/',
   plugins: [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "landing-page",
-  "description": "the front-facing page for Gastown Gang",
-  "version": "0.1.0",
+  "description": "the front-facing page for Cambie Collective",
+  "version": "0.1.1",
   "author": "Manil Chowdhury",
   "dependencies": {
     "gatsby": "^1.9.235",
@@ -21,7 +21,7 @@
     "react-scrollspy": "^3.3.5",
     "react-waypoint": "^8.0.1"
   },
-  "homepage": "https://gastowngang.github.io",
+  "homepage": "https://cambiecollective.github.io",
   "keywords": [
     "gatsby"
   ],
@@ -29,7 +29,7 @@
   "main": "n/a",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gastowngang/gastowngang.github.io.git"
+    "url": "https://github.com/cambiecollective/cambiecollective.github.io.git"
   },
   "scripts": {
     "build": "gatsby build",

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -5,16 +5,16 @@ const Footer = (props) => (
     <footer id="footer">
         <section>
             <h2>We Are Open Source</h2>
-            <p>Gastown Gang operates transparently. We welcome all contributions!</p>
+            <p>Cambie Collective operates transparently. We welcome all contributions!</p>
             <ul className="actions">
-                <li><a href="https://github.com/gastowngang/gastowngang.github.io" className="button">Join us!</a></li>
+                <li><a href="https://github.com/cambiecollective/cambiecollective.github.io" className="button">Join us!</a></li>
             </ul>
         </section>
         <section>
             <h2>Find us on the internet</h2>
             <ul className="icons">
-                <li><a href="https://twitter.com/gastowngang" className="icon fa-twitter alt"><span className="label">Twitter</span></a></li>
-                <li><a href="https://github.com/gastowngang/gastowngang.github.io" className="icon fa-github alt"><span className="label">GitHub</span></a></li>
+                <li><a href="https://twitter.com/cambiecollective" className="icon fa-twitter alt"><span className="label">Twitter</span></a></li>
+                <li><a href="https://github.com/cambiecollective/cambiecollective.github.io" className="icon fa-github alt"><span className="label">GitHub</span></a></li>
             </ul>
         </section>
         <p className="copyright">&copy; Manil Chowdhury. Design: <a href="https://html5up.net">HTML5 UP</a>.</p>

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -13,7 +13,7 @@ const Footer = (props) => (
         <section>
             <h2>Find us on the internet</h2>
             <ul className="icons">
-                <li><a href="https://twitter.com/cambiecollective" className="icon fa-twitter alt"><span className="label">Twitter</span></a></li>
+                <li><a href="https://twitter.com/cambiecollectiv" className="icon fa-twitter alt"><span className="label">Twitter</span></a></li>
                 <li><a href="https://github.com/cambiecollective/cambiecollective.github.io" className="icon fa-github alt"><span className="label">GitHub</span></a></li>
             </ul>
         </section>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -6,7 +6,7 @@ import logo from '../assets/images/logo-rocket.svg';
 const Header = (props) => (
     <header id="header" className="alt">
         {/* <span className="logo"><img src={logo} alt="" /></span> */}
-        <h1>Gastown Gang 🏭</h1>
+        <h1>Cambie Collective 🏭</h1>
         <p>a Vancouver-focused community and events team for the tech and maker community</p>
     </header>
 )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -112,7 +112,7 @@ class Index extends React.Component {
             </ul>
             <p className="content">Our audience is a diverse mix of interests. 
               With 7900 members and counting, our responsibility to create healthy 
-              communities continues to grow. You're welcome to join us as an audience member, a sponsor, a venue partner, or even as a contributor. 🎉 What does that mean? <a href='https://twitter.com/cambiecollective/following'>Tweet at or DM any of us</a> to find out.</p>
+              communities continues to grow. You're welcome to join us as an audience member, a sponsor, a venue partner, or even as a contributor. 🎉 What does that mean? <a href='https://twitter.com/cambiecollectiv/following'>Tweet at or DM any of us</a> to find out.</p>
             <footer className="major">
               <ul className="actions">
                 <li><Link to="/" className="button">Learn More</Link></li>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -112,7 +112,7 @@ class Index extends React.Component {
             </ul>
             <p className="content">Our audience is a diverse mix of interests. 
               With 7900 members and counting, our responsibility to create healthy 
-              communities continues to grow. You're welcome to join us as an audience member, a sponsor, a venue partner, or even as a contributor. 🎉 What does that mean? <a href='https://twitter.com/gastowngang/following'>Tweet at or DM any of us</a> to find out.</p>
+              communities continues to grow. You're welcome to join us as an audience member, a sponsor, a venue partner, or even as a contributor. 🎉 What does that mean? <a href='https://twitter.com/cambiecollective/following'>Tweet at or DM any of us</a> to find out.</p>
             <footer className="major">
               <ul className="actions">
                 <li><Link to="/" className="button">Learn More</Link></li>


### PR DESCRIPTION
Change page mentions of org. name "gastown gang" to "cambie collective".

## TODO:
- [x]  Should twitter handle https://twitter.com/gastowngang be changed to https://twitter.com/cambiecollective?

---

Resolves: #26 
Related: #14 